### PR TITLE
Fix exceptions thrown when incoming MIDI messages are not instances of ShortMessage

### DIFF
--- a/src/overtone/midi.clj
+++ b/src/overtone/midi.clj
@@ -201,7 +201,7 @@
 ;;
 ;; http://www.jsresources.org/faq_midi.html#no_note_off
 (defn midi-msg
-  "Make a clojure map out of a midi object."
+  "Make a clojure map out of a midi ShortMessage object."
   [^ShortMessage obj & [ts]]
   (let [ch     (.getChannel obj)
         cmd    (.getCommand obj)

--- a/src/overtone/midi.clj
+++ b/src/overtone/midi.clj
@@ -227,9 +227,10 @@
   [input fun]
   (let [receiver (proxy [Receiver] []
                    (close [] nil)
-                   (send [msg timestamp] (fun
-                                           (assoc (midi-msg msg timestamp)
-                                                  :device input))))]
+                   (send [msg timestamp] (when (instance? ShortMessage msg )
+                                           (fun
+                                            (assoc (midi-msg msg timestamp)
+                                              :device input)))))]
     (.setReceiver (:transmitter input) receiver)
     receiver))
 


### PR DESCRIPTION
This fixes overtone issue #119:

https://github.com/overtone/overtone/issues/119
