### PR TITLE
Use CoreMidi4J devices when available.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,4 +3,4 @@
                 interact with external midi devices."
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [overtone/at-at "1.0.0"]
-                 [uk.co.xfactory-librarians/coremidi4j "0.7"]])
+                 [uk.co.xfactory-librarians/coremidi4j "0.8"]])

--- a/project.clj
+++ b/project.clj
@@ -2,4 +2,5 @@
   :description "A high level midi library to read files, play notes, and
                 interact with external midi devices."
   :dependencies [[org.clojure/clojure "1.3.0"]
-                 [overtone/at-at "1.0.0"]])
+                 [overtone/at-at "1.0.0"]
+                 [uk.co.xfactory-librarians/coremidi4j "0.7"]])

--- a/src/overtone/midi.clj
+++ b/src/overtone/midi.clj
@@ -14,8 +14,7 @@
      (javax.swing JFrame JScrollPane JList
                   DefaultListModel ListSelectionModel)
      (java.awt.event MouseAdapter)
-     (java.util.concurrent FutureTask ScheduledThreadPoolExecutor TimeUnit)
-     (uk.co.xfactorylibrarians.coremidi4j CoreMidiDeviceProvider))
+     (java.util.concurrent FutureTask ScheduledThreadPoolExecutor TimeUnit))
   (:use clojure.set)
   (:require [overtone.at-at :as at-at]))
 
@@ -27,14 +26,22 @@
 
 (def get-midi-device-info
   "Will contain a function to invoke the appropriate version of the
-  getMidiDeviceInfo method. If CoreMidi4J is running, which means this
-  is a Mac and we have fixed versions of the MIDI devices available
-  which properly support SysEx messages and timestamps, the function
-  will use the CoreMidi4J version. Otherwise it will use the standard
-  Java version."
-  (if (CoreMidiDeviceProvider/isLibraryLoaded)
-    #(CoreMidiDeviceProvider/getMidiDeviceInfo)
-    #(MidiSystem/getMidiDeviceInfo)))
+  getMidiDeviceInfo method. If CoreMidi4J is installed and running,
+  which means this is a Mac, we are running Java 7 or later, and we
+  therefore have fixed versions of the MIDI devices available which
+  properly support SysEx messages and timestamps, the function will
+  use the CoreMidi4J method. Otherwise it will use the standard Java
+  method."
+  (try
+    (let [provider (Class/forName "uk.co.xfactorylibrarians.coremidi4j.CoreMidiDeviceProvider")
+          library-loaded-method (.getMethod provider "isLibraryLoaded" (make-array Class 0))
+          device-info-method (.getMethod provider "getMidiDeviceInfo" (make-array Class 0))
+          empty-object-args (make-array Object 0)]
+      (if (.invoke library-loaded-method nil empty-object-args)
+        #(.invoke device-info-method nil empty-object-args) ; CoreMidi4J is present and running. Use it.
+        #(MidiSystem/getMidiDeviceInfo)))  ; CoreMidi4J is present but not running (i.e. not a Mac). Use standard.
+    (catch ClassNotFoundException e
+      #(MidiSystem/getMidiDeviceInfo))))   ; CoreMidi4J is not present. Use standard implementation.
 
 (defn midi-devices []
   "Get all of the currently available midi devices."


### PR DESCRIPTION
The standard Java MIDI device implementations on Mac OS do not (and
never have) supported System Exclusive messages. They also do not
properly support MIDI timestamps, even though the underlying CoreMIDI
implementation does, even over the network using RTP-MIDI.

This change embeds the CoreMidi4J library, which offers fixed versions
of the broken MIDI device implementations on Mac OS X, and remains
safely idle on other platforms. When CoreMidi4J is active, its versions
of MIDI device implementations are used instead of the broken ones.
